### PR TITLE
Reload non cogs

### DIFF
--- a/nrus/modules/admin.py
+++ b/nrus/modules/admin.py
@@ -13,7 +13,8 @@ from discord.ext import commands
 from bot import NRus
 
 
-GIT_CHANGED_FILE: Pattern = re.compile(r'nrus/(.+?).py \| [1-9] \+*-*')
+# Matches one or more spaces because git output contains extra spaces to line up output
+GIT_CHANGED_FILE: Pattern = re.compile(r'nrus/(.+?).py +\| +[1-9] +\+*-*')
 
 
 class Admin(commands.Cog):
@@ -116,7 +117,7 @@ class Admin(commands.Cog):
     def find_changed_modules(self, git_output: bytes) -> list:
         changed_files = []
         for line in git_output.decode().split('\n'):
-            match: Match = GIT_CHANGED_FILE.match(line)
+            match: Match = GIT_CHANGED_FILE.search(line)
             if match:
                 relative_path = match.group(1)
                 module_name = '.'.join(relative_path.split('/'))

--- a/nrus/modules/admin.py
+++ b/nrus/modules/admin.py
@@ -4,6 +4,7 @@ import importlib
 import json
 import re
 import subprocess
+import sys
 from typing import Match, Optional, Pattern
 
 import discord
@@ -97,13 +98,17 @@ class Admin(commands.Cog):
             if 'bot' in changed_modules:
                 await ctx.send('nrus/bot.py was changed. Restarting NRus...')
                 await self.bot.logout()
-            for module in changed_modules:
-                if module.startswith('modules.'):
-                    await ctx.send(f'Warning: {module} is in nrus/modules/ but is not in {self.bot.extension_file}')
+            for name in changed_modules:
+                if name.startswith('modules.'):
+                    await ctx.send(f'Warning: {name} is in nrus/modules/ but is not in {self.bot.extension_file}')
+                module = sys.modules.get(name)
+                if module is None:
+                    await ctx.send(f'Warning: Module {name} was changed but is not loaded')
+                    continue
                 try:
                     importlib.reload(module)
                 except Exception as e:
-                    await ctx.send(f'Error loading {module}: {e.__class__.__name__}: {e}')
+                    await ctx.send(f'Error loading {name}: {e.__class__.__name__}: {e}')
             await ctx.send('Checkout Successful')
         else:
             await ctx.send('Git checkout failed, not reloading extensions')

--- a/nrus/modules/admin.py
+++ b/nrus/modules/admin.py
@@ -96,8 +96,8 @@ class Admin(commands.Cog):
             # Reload python files that are not extensions because these files will not be reloaded
             # Start by getting list of changed files from git output
             changed_modules = self.find_changed_modules(output.stdout)
-            if 'bot' in changed_modules:
-                await ctx.send('nrus/bot.py was changed. Restarting NRus...')
+            if {'bot', 'main'}.intersection(changed_modules):
+                await ctx.send('nrus/bot.py or nrus/main.py was changed. Restarting NRus...')
                 await self.bot.logout()
             for name in changed_modules:
                 if name.startswith('modules.'):

--- a/nrus/modules/admin.py
+++ b/nrus/modules/admin.py
@@ -2,7 +2,6 @@ import asyncio
 import functools
 import importlib
 import json
-import os
 import re
 import subprocess
 from typing import Match, Optional, Pattern
@@ -115,12 +114,12 @@ class Admin(commands.Cog):
             match: Match = GIT_CHANGED_FILE.match(line)
             if match:
                 relative_path = match.group(1)
-                module_name = '.'.join(os.path.split(relative_path))
+                module_name = '.'.join(relative_path.split('/'))
                 changed_files.append(module_name)
         # Remove files that are in the extensions file
         with open(self.bot.extension_file) as f:
             extensions = json.load(f)
-        return list(filter(lambda a: a not in extensions, changed_files))
+        return [file for file in changed_files if file not in extensions]
 
 
 def setup(bot: NRus):


### PR DESCRIPTION
- Increases uptime by not needing to restart the bot for changes to files other than `bot.py` or `main.py`
- Automatically stops bot if needed (will be restarted by systemd)